### PR TITLE
use correct iter value

### DIFF
--- a/components/CustomButton.js
+++ b/components/CustomButton.js
@@ -4,9 +4,14 @@ class CustomButton extends React.PureComponent {
   render() {
     const { onClick, hasError, updateProps, iter, ...props } = this.props;
     return (
-      <button {...props} onClick={() => {for (let t = 0; t < 10; t++) {
+      <button {...props} onClick={() => {
+        for (let t = 0; t < 10; t++) {
           console.log(t, iter);
-          setTimeout(() => updateProps({ iter: iter + 1 }), 20 * t); }}} />
+          setTimeout(() => {
+            updateProps({ iter: this.props.iter + 1 })
+          }, 20 * t);
+        }
+      }} />
     );
   }
 }


### PR DESCRIPTION
This refers to `this.props.iter` so that the update is always referring to the current value, rather than capturing the value when the loop starts. 
![riffler](https://user-images.githubusercontent.com/1074773/41000760-d75fb4a8-68c3-11e8-917d-e62c85b6e825.gif)
